### PR TITLE
Use entry's buildOptions instead of the argument

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vite-plugin-vercel",
-  "version": "6.0.1",
+  "name": "@clearyai/vite-plugin-vercel",
+  "version": "6.1.0",
   "type": "module",
   "files": [
     "dist",

--- a/packages/vercel/src/build.ts
+++ b/packages/vercel/src/build.ts
@@ -109,7 +109,6 @@ const standardBuildOptions: BuildOptions = {
 export async function buildFn(
   resolvedConfig: ResolvedConfig,
   entry: ViteVercelApiEntry,
-  buildOptions?: BuildOptions,
 ) {
   assert(
     entry.destination.length > 0,
@@ -120,8 +119,8 @@ export async function buildFn(
 
   const options = Object.assign({}, standardBuildOptions);
 
-  if (buildOptions) {
-    Object.assign(options, buildOptions);
+  if (entry.buildOptions) {
+    Object.assign(options, entry.buildOptions);
   }
 
   const filename =

--- a/packages/vike-integration/package.json
+++ b/packages/vike-integration/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.4.5",
     "vike": "^0.4.171",
     "vite": "^5.2.11",
-    "vite-plugin-vercel": "workspace:*"
+    "@clearyai/vite-plugin-vercel": "workspace:*"
   },
   "dependencies": {
     "@brillout/libassert": "^0.5.8",
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "vike": "^0.4.171",
     "vite": "^4.4 || ^5.0.2",
-    "vite-plugin-vercel": "*"
+    "@clearyai/vite-plugin-vercel": "*"
   },
   "license": "MIT"
 }

--- a/packages/vike-integration/vike.ts
+++ b/packages/vike-integration/vike.ts
@@ -9,7 +9,7 @@ import type {
   ViteVercelApiEntry,
   ViteVercelPrerenderFn,
   ViteVercelPrerenderRoute,
-} from 'vite-plugin-vercel';
+} from '@clearyai/vite-plugin-vercel';
 import 'vike/__internal/setup';
 import {
   getPagesAndRoutes,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - 'packages/*'
-  - 'examples/*'
+  # - 'examples/*'

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "redirects": [{ "source": "/redirect", "destination": "/static" }]
-}


### PR DESCRIPTION
This PR uses `entry.buildOptions` rather than the argument so that things such as sourcemap support for an entry are configurable. 